### PR TITLE
Update solution and tests for Power

### DIFF
--- a/app/src/test/java/com/igorwojda/integer/power/Power.kt
+++ b/app/src/test/java/com/igorwojda/integer/power/Power.kt
@@ -10,21 +10,36 @@ private fun power(base: Int, exponent: Int): Int {
 class PowerTest {
     @Test
     fun `power 2^1 returns 2`() {
-        power(2, 1) shouldEqual 2
+        power(2, 1) shouldEqual Math.pow(2.0, 1.0).toInt()
     }
 
     @Test
     fun `power 2^2 returns 2`() {
-        power(2, 2) shouldEqual 4
+        power(2, 2) shouldEqual Math.pow(2.0, 2.0).toInt()
     }
 
     @Test
     fun `power 2^3 returns 8`() {
-        power(2, 3) shouldEqual 8
+        power(2, 3) shouldEqual Math.pow(2.0, 3.0).toInt()
     }
 
     @Test
     fun `power 3^4 returns 81`() {
-        power(3, 4) shouldEqual 81
+        power(3, 4) shouldEqual Math.pow(3.0, 4.0).toInt()
+    }
+
+    @Test
+    fun `power 3^-1 returns 0`() {
+        power(3, -1) shouldEqual Math.pow(3.0, -1.0).toInt()
+    }
+
+    @Test
+    fun `power 3^0 returns 1`() {
+        power(3, 0) shouldEqual Math.pow(3.0, 0.0).toInt()
+    }
+
+    @Test
+    fun `power 3^-2 returns 0`() {
+        power(3, -2) shouldEqual Math.pow(3.0, -2.0).toInt()
     }
 }

--- a/app/src/test/java/com/igorwojda/integer/power/PowerSolution.kt
+++ b/app/src/test/java/com/igorwojda/integer/power/PowerSolution.kt
@@ -1,14 +1,29 @@
 package com.igorwojda.integer.power
 
 // Recursive solution
-private object Solution {
+private object Solution1 {
     private fun power(base: Int, exponent: Int): Int {
         println("$base, $exponent")
         if (exponent == 1) {
             return base
         }
-
         return base * power(base, exponent - 1)
+    }
+}
+
+private object Solution2 {
+    private fun power(base: Int, exponent: Int): Int {
+        println("$base, $exponent")
+        return when(exponent) {
+            in Int.MIN_VALUE..-1 -> {
+                val b = 1 / base
+                val e = -exponent
+                b * power(b, e - 1)
+            }
+            0 -> 1
+            1 -> base
+            else -> base * power(base, exponent - 1)
+        }
     }
 }
 


### PR DESCRIPTION
1. Updated tests to compare results with the `Math.pow()` methods
2. Added a solution that employs the use of the `when` construct and covers the case of negative exponents (however for `Int` these end up resulting in `0`. If the original problem used `Double` this would be more effective). 

